### PR TITLE
Allow `RS` to take a Base64-encoded key as input

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Felipe Noronha <felipenoris@gmail.com>"]
 version = "1.0.1"
 
 [deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 MbedTLS = "739be429-bea8-5141-9913-cc70e7f3736d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/JSONWebTokens.jl
+++ b/src/JSONWebTokens.jl
@@ -17,6 +17,7 @@ none    No digital signature or MAC value included
 =#
 
 import JSON, SHA, MbedTLS
+import Base64
 using Random
 
 abstract type Encoding end


### PR DESCRIPTION
**Before this PR:** `RS` can take any of the following as input:
- Filename to the key file
- Contents of the key

**After this PR:** `RS` can take any of the following as input:
- Filename to the key file
- Contents of the key
- Base64-encoded of the key

## Motivation 

In some situations, you may not be able to define environment variables that have newline characters in the values. Therefore, for public keys and private keys, you may want to Base64-encode them. This PR allows `RS` (e.g. `RS{256}` or `RS{384}`) to take Base64-encoded keys as input.