### PR TITLE
Ability to provide additional header claims

### DIFF
--- a/src/JSONWebTokens.jl
+++ b/src/JSONWebTokens.jl
@@ -32,5 +32,6 @@ include("jws.jl")
 include("none.jl")
 include("hs.jl")
 include("rs.jl")
+include("header_claims.jl")
 
 end

--- a/src/header_claims.jl
+++ b/src/header_claims.jl
@@ -1,0 +1,21 @@
+function _header_json(
+        encoding;
+        additional_header_dict::AbstractDict,
+    )
+    # The `additional_header_dict` dictionary is not allowed to have a key named
+    # "alg" or "typ", because we are going to define those keys ourselves.
+    for claim in ("alg", "typ")
+        if haskey(additional_header_dict, claim)
+            msg = "additional_header_dict is not allowed to have a key named $(claim)"
+            error(msg)
+        end
+    end
+    header_dict = Dict{String, String}()
+    for (k, v) in pairs(additional_header_dict)
+        header_dict[k] = v
+    end
+    header_dict["typ"] = "JWT"
+    header_dict["alg"] = alg(encoding)
+    header_json = JSON.json(header_dict)::String
+    return header_json
+end

--- a/src/jws.jl
+++ b/src/jws.jl
@@ -125,12 +125,24 @@ function verify(encoding::Encoding, str::AbstractString)
     nothing
 end
 
-function encode(encoding::Encoding, claims_dict::Dict{S, A}) where {S<:AbstractString, A}
-    return encode(encoding, JSON.json(claims_dict))
-end
 
-function encode(encoding::Encoding, claims_json::AbstractString)
-    header_encoded = base64url_encode("""{"alg":"$(alg(encoding))","typ":"JWT"}""")
+function encode(
+        encoding::Encoding,
+        claims_dict::Dict{S, A};
+        additional_header_dict = Dict(),
+    ) where {S<:AbstractString, A}
+    return encode(encoding, JSON.json(claims_dict); additional_header_dict = additional_header_dict)
+
+function encode(
+        encoding::Encoding,
+        claims_json::AbstractString;
+        additional_header_dict = Dict(),
+    )
+    header_json = _header_json(
+        encoding;
+        additional_header_dict=additional_header_dict,
+    )
+    header_encoded = base64url_encode(header_json)
     claims_encoded = base64url_encode(claims_json)
     header_and_claims_encoded = header_encoded * "." * claims_encoded
     signature = sign(encoding, header_and_claims_encoded)

--- a/src/jws.jl
+++ b/src/jws.jl
@@ -1,4 +1,3 @@
-
 function base64url_encode(s) :: String
     encoded_str = Base64URL.base64urlencode(s)
 
@@ -125,13 +124,13 @@ function verify(encoding::Encoding, str::AbstractString)
     nothing
 end
 
-
 function encode(
         encoding::Encoding,
         claims_dict::Dict{S, A};
         additional_header_dict = Dict(),
     ) where {S<:AbstractString, A}
-    return encode(encoding, JSON.json(claims_dict); additional_header_dict = additional_header_dict)
+    return encode(encoding, JSON.json(claims_dict); additional_header_dict=additional_header_dict)
+end
 
 function encode(
         encoding::Encoding,

--- a/src/none.jl
+++ b/src/none.jl
@@ -1,4 +1,3 @@
-
 struct None <: Encoding
 end
 
@@ -9,8 +8,16 @@ function decode(::None, str::AbstractString)
     return jws_claims_dict(claims_encoded)
 end
 
-function encode(encoding::None, claims_json::AbstractString)
-    header_encoded = base64url_encode("""{"alg":"$(alg(encoding))","typ":"JWT"}""")
+function encode(
+        encoding::None,
+        claims_json::AbstractString;
+        additional_header_dict = Dict(),
+    )
+    header_json = _header_json(
+        encoding;
+        additional_header_dict=additional_header_dict,
+    )
+    header_encoded = base64url_encode(header_json)
     claims_encoded = base64url_encode(claims_json)
     header_and_claims_encoded = header_encoded * "." * claims_encoded
     return header_and_claims_encoded

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -263,3 +263,9 @@ end
         @test_throws ErrorException JSONWebTokens._header_json(encoding; additional_header_dict = Dict("typ" => ""))
     end
 end
+
+@testset "errors.jl" begin
+    @test JSONWebTokens.InvalidSignatureError() isa Exception
+    @test JSONWebTokens.MalformedJWTError() isa Exception
+    @test JSONWebTokens.NotSupportedJWTError() isa Exception
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -266,6 +266,6 @@ end
 
 @testset "errors.jl" begin
     @test JSONWebTokens.InvalidSignatureError() isa Exception
-    @test JSONWebTokens.MalformedJWTError() isa Exception
-    @test JSONWebTokens.NotSupportedJWTError() isa Exception
+    @test JSONWebTokens.MalformedJWTError("foo") isa Exception
+    @test JSONWebTokens.NotSupportedJWTError("foo") isa Exception
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,3 @@
-
 import JSONWebTokens, SHA, MbedTLS, JSON
 
 using Test
@@ -41,7 +40,7 @@ end
     encoding = JSONWebTokens.HS256("secretkey")
     claims_json = """{"sub":"1234567890","name":"John Doe","iat":1516239022}"""
     claims_dict = JSON.parse(claims_json)
-    @test JSONWebTokens.encode(encoding, claims_json) == "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.8TLPbKjmE0uGLQyLnfHx2z-zy6G8qu5zFFXRSuJID_Y"
+    @test JSONWebTokens.encode(encoding, claims_json) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.eLWVGTagnM7bixRmtk8GQHLzC10ZdAJlRjWyD2NDwzQ"
     @test JSONWebTokens.decode(encoding, JSONWebTokens.encode(encoding, claims_dict)) == claims_dict
 end
 
@@ -88,7 +87,7 @@ end
 
     claims_dict = JSON.parse("""{"sub":"1234567890","name":"John Doe","admin":true,"iat":1516239022}""")
     jwt = JSONWebTokens.encode(rsa_private, claims_dict)
-    @test startswith(jwt, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.")
+    @test startswith(jwt, "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.")
     @test JSONWebTokens.decode(rsa_public, jwt) == claims_dict
 
     fp_public2 = joinpath(@__DIR__, "public2.pem")
@@ -154,7 +153,7 @@ hL1Hq+f0MJkBnql53kFDSth1fQSkSMMHIb1LGFYmoT3mSDwHDho=
 
     claims_dict = JSON.parse("""{"sub":"1234567890","name":"John Doe","admin":true,"iat":1516239022}""")
     jwt = JSONWebTokens.encode(rsa_private, claims_dict)
-    @test startswith(jwt, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.")
+    @test startswith(jwt, "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.")
     @test JSONWebTokens.decode(rsa_public, jwt) == claims_dict
 
     @testset "base64 encoded key" begin
@@ -213,7 +212,7 @@ AwIDAQAB
 
     claims_dict = JSON.parse("""{"sub":"1234567890","name":"John Doe","admin":true,"iat":1516239022}""")
     jwt = JSONWebTokens.encode(rsa_private, claims_dict)
-    @test startswith(jwt, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.")
+    @test startswith(jwt, "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.")
     @test JSONWebTokens.decode(rsa_public, jwt) == claims_dict
 
     @testset "base64 encoded key" begin


### PR DESCRIPTION
I have a use case where I need to provide an optional header claim. In my use case, I specifically need to provide the `kid` (key ID) header claim. However, I figured I'd make this PR more general. In this PR, the user can provide any optional header claims that they like. Of course, we don't let the user override `typ` or `alg`, but they can specify any other header claims.

---

### Reference tests

Note: Prior to this PR, the header claims were hardcoded in the JSONWebTokens.jl source code like this:

```json
{"alg":"RS256","typ":"JWT"}
```

In particular, note that the JSONWebTokens.jl source code hardcoded the order of the keys: first `alg`, and then `typ`.

After this PR, we create the header claims as a Julia `Dict` and then use JSON.jl to convert the `Dict` to a JSON string. This means that the JSON.jl package gets to decide which order the keys are printed in.

For the case where there are just two keys (`typ` and `alg`), we see that JSON.jl returns the following:

```julia
julia> JSON.json(Dict("typ" => "JWT", "alg" => "RS256"))
"{\"typ\":\"JWT\",\"alg\":\"RS256\"}"

julia> JSON.json(Dict("alg" => "RS256", "typ" => "JWT"))
"{\"typ\":\"JWT\",\"alg\":\"RS256\"}"
```

In other words, JSON.jl is outputting the following JSON:

```json
{"typ":"JWT","alg":"RS256"}
```

Therefore, the key order chosen by JSON.jl is first `typ` and then `alg`.

Because of this change in the key order, some of the reference tests are broken by this PR. I have fixed the reference tests by putting in the new values - see commit.