### PR TITLE
Prepare to release version 1.1.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JSONWebTokens"
 uuid = "9b8beb19-0777-58c6-920b-28f749fee4d3"
 authors = ["Felipe Noronha <felipenoris@gmail.com>"]
-version = "1.1.2-dev"
+version = "1.1.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
I have a feature PR open currently (#21). Because that PR introduces a new feature, it should correspond to a minor version number bump, i.e. 1.2.0.

So, before we merge #21, we should release version 1.1.2.